### PR TITLE
feat(DI): register individual effect instances with the DI

### DIFF
--- a/lib/run-effects.ts
+++ b/lib/run-effects.ts
@@ -6,13 +6,16 @@ import { STATE_UPDATES_PROVIDER } from './state-updates';
 
 
 export function runEffects(...effects: any[]) {
-  const allEffects = flatten(effects)
-    .map(effect => new Provider(BOOTSTRAP_EFFECTS, {
-      useClass: effect,
+  const individuals = flatten(effects);
+
+  const allEffects = individuals
+    .map(effectClass => new Provider(BOOTSTRAP_EFFECTS, {
+      useExisting: effectClass,
       multi: true
     }));
 
   return [
+    ...individuals,
     ...allEffects,
     CONNECT_EFFECTS_PROVIDER,
     STATE_UPDATES_PROVIDER


### PR DESCRIPTION
By registering individual effect instances with the DI, we can inject instances of running effects into our components. This would be useful if one needs to configure a running effect, without having to manually wire up and run the effects.

In my specific scenario, I wanted to be able to provide a particular [`NavController`](http://ionicframework.com/docs/v2/2.0.0-beta.7/api/components/nav/NavController/) instance for my `NavEffects` below to use. With this change, I can simply inject `NavEffects` into my component constructor, and call `setRootNav` on it.

``` ts
@Injectable()
export class NavEffects {
  @Effect()
  public push$ = this.updates$
    .whenAction(...)
    .switchMap((update: StateUpdate<any>) => {
      return this.rootNavController.push(MyPage).then(() => {
        // ...
      });
    });

  constructor(
    private updates$:StateUpdates<AppState>
  ) {
  }

  public setRootNav(navController:NavController) {
    this.rootNavController = navController;    // need to call this at some point
  }

  private rootNavController:NavController;
}
```
