### PR TITLE
Add support for functions returning Observable.

### DIFF
--- a/lib/effects.ts
+++ b/lib/effects.ts
@@ -5,7 +5,14 @@ import { getEffectKeys } from './metadata';
 import { flatten } from './util';
 
 export function mergeEffects(...instances: any[]): Observable<any> {
-  const observables = flatten(instances).map(i => getEffectKeys(i).map(key => i[key]));
+  const observables: Observable<any>[] = flatten(instances).map((i: any): any => getEffectKeys(i).map(
+    (key: string): Observable<any> => {
+        if (typeof i[key] === 'function') {
+            return i[key]();
+        }
+        return i[key];
+    }
+  ));
 
   return Observable.merge(...flatten(observables));
 }

--- a/spec/effects.spec.ts
+++ b/spec/effects.spec.ts
@@ -10,10 +10,11 @@ describe('mergeEffects', function() {
       @Effect() a = Observable.of('a');
       @Effect() b = Observable.of('b');
       @Effect() c = Observable.of('c');
+      @Effect() d() { return Observable.of('d'); }
     }
 
     const mock = new Fixture();
-    const expected = ['a', 'b', 'c'];
+    const expected = ['a', 'b', 'c', 'd'];
 
     mergeEffects(mock).toArray().subscribe({
       next(actual) {
@@ -37,9 +38,13 @@ describe('mergeEffects', function() {
       @Effect() c = Observable.of('c');
     }
 
-    const expected = ['a', 'b', 'c'];
+    class Fourth {
+      @Effect() d() { return Observable.of('d'); }
+    }
 
-    mergeEffects([ new First(), new Second(), new Third() ]).toArray().subscribe({
+    const expected = ['a', 'b', 'c', 'd'];
+
+    mergeEffects([ new First(), new Second(), new Third(), new Fourth() ]).toArray().subscribe({
       next(actual) {
         expect(actual).toEqual(expected);
       },


### PR DESCRIPTION
By being able to decorate functions with @Effect, the order in which the class members are added by the TypeScript compiler in the generated JS code is preserved, so no errors any more when declaring member properties outside the constructor.
