### PR TITLE
(bugfix) remove deprecated Provider from testing.ts

### DIFF
--- a/lib/testing.ts
+++ b/lib/testing.ts
@@ -1,6 +1,5 @@
 import { ReplaySubject } from 'rxjs/ReplaySubject';
 import { Action } from '@ngrx/store';
-import { Provider } from '@angular/core';
 import { filter } from 'rxjs/operator/filter';
 import { Observable } from 'rxjs/Observable';
 import { StateUpdate, StateUpdates } from './state-updates';
@@ -30,10 +29,6 @@ export class MockStateUpdates extends ReplaySubject<StateUpdate<any>> {
 }
 
 export const MOCK_EFFECTS_PROVIDERS = [
-  new Provider(MockStateUpdates, {
-    useClass: MockStateUpdates
-  }),
-  new Provider(StateUpdates, {
-    useExisting: MockStateUpdates
-  })
+  {provide: MockStateUpdates, useClass: MockStateUpdates},
+  {provide: StateUpdates, useExisting: MockStateUpdates}
 ];

--- a/package.json
+++ b/package.json
@@ -41,12 +41,12 @@
     "@ngrx/store": "^2.0.0"
   },
   "devDependencies": {
-    "@angular/common": "^2.0.0-rc.1",
-    "@angular/compiler": "^2.0.0-rc.1",
-    "@angular/core": "^2.0.0-rc.1",
-    "@angular/platform-browser": "^2.0.0-rc.1",
-    "@angular/platform-browser-dynamic": "^2.0.0-rc.1",
-    "@ngrx/core": "^1.0.0",
+    "@angular/common": "2.0.0-rc.1",
+    "@angular/compiler": "2.0.0-rc.1",
+    "@angular/core": "2.0.0-rc.1",
+    "@angular/platform-browser": "2.0.0-rc.1",
+    "@angular/platform-browser-dynamic": "2.0.0-rc.1",
+    "@ngrx/core": "1.0.0",
     "conventional-changelog-cli": "^1.1.1",
     "core-js": "^2.2.2",
     "istanbul-instrumenter-loader": "^0.2.0",
@@ -68,6 +68,6 @@
     "typescript": "^1.8.9",
     "typings": "^0.7.12",
     "webpack": "^1.12.14",
-    "zone.js": "^0.6.8"
+    "zone.js": "0.6.12"
   }
 }


### PR DESCRIPTION
just a real simple quick fix to allow this to run in rc6+
not doing the module dance just yet before you acknowledge it will be approved... 
