### PR TITLE
chore(docs): Testing correctness and completeness

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -9,7 +9,7 @@
       imports: [
         EffectsTestingModule
       ],
-      declarations: [
+      providers: [
         AuthEffects
       ]
     }));
@@ -19,13 +19,16 @@
 2. Inject the `EffectsTestRunner`:
   ```ts
   let runner: EffectsRunner;
+  let authEffects: AuthEffects;
 
   beforeEach(inject([
-    EffectsRunner,
-    (_runner) => {
+      EffectsRunner, AuthEffects
+    ],
+    (_runner, _authEffects) => {
       runner = _runner;
+      authEffects = _authEffects;
     }
-  ]));
+  ));
   ```
 
 3. Queue up actions and then subscribe to the effect you want to test asserting


### PR DESCRIPTION
- the inject call params were incorrect `inject([injections, fn])` -> `inject([injections], fn)`
- step 3 referenced authEffects which was not reflected in step 2
- effects needed to be specified as a provider in the test module setup, rather than a declaration
