### PR TITLE
Remove unused lifecycle hook from intro example

### DIFF
--- a/docs/intro.md
+++ b/docs/intro.md
@@ -18,7 +18,7 @@ observable service that emits every action dispatched in your application.
   import { Actions, Effect } from '@ngrx/effects';
 
   @Injectable()
-  export class AuthEffects implements OnDestroy {
+  export class AuthEffects {
     constructor(
       private http: Http,
       private actions$: Actions


### PR DESCRIPTION
For #73. Small readme change for intro example, to remove lifecycle hook reference from previous example code.