### PR TITLE
Now you can choose between `@Effect()` decorator and custom effect pr…

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -3,3 +3,4 @@ export { Actions } from './src/actions';
 export { EffectsModule } from './src/effects.module';
 export { EffectsSubscription } from './src/effects-subscription';
 export { toPayload } from './src/util';
+export { effectsConfig, EffectsConfiguration } from './src/effects.config';

--- a/spec/effects-subscription.spec.ts
+++ b/spec/effects-subscription.spec.ts
@@ -2,6 +2,7 @@ import { ReflectiveInjector } from '@angular/core';
 import { of } from 'rxjs/observable/of';
 import { Effect } from '../src/effects';
 import { EffectsSubscription } from '../src/effects-subscription';
+import { EffectsConfiguration } from '../src/effects.config';
 
 
 describe('Effects Subscription', () => {
@@ -40,5 +41,17 @@ describe('Effects Subscription', () => {
     expect(observer.next).toHaveBeenCalledWith('a');
     expect(observer.next).toHaveBeenCalledWith('b');
     expect(observer.next).toHaveBeenCalledWith('c');
+  });
+
+  it('should use `Effect` decorator in first priority and ignore prefix', () => {
+    class Source {
+      @Effect({ dispatch: false }) effectA$ = of('a');
+    }
+    const instance = new Source();
+    const observer: any = { next: jasmine.createSpy('next') };
+
+    const subscription = new EffectsSubscription(observer, null, [instance], <EffectsConfiguration> { registerEffectWithPrefix: 'effect'});
+
+    expect(observer.next).toHaveBeenCalledTimes(1);
   });
 });

--- a/spec/effects.spec.ts
+++ b/spec/effects.spec.ts
@@ -23,4 +23,42 @@ describe('mergeEffects', function() {
       complete: done
     });
   });
+
+  it('should merge all observable sources decorated with @Effect()', function(done) {
+    class Fixture {
+      @Effect() a = Observable.of('a');
+      @Effect() b = Observable.of('b');
+      @Effect({ dispatch: false }) c = Observable.of('c');
+      @Effect() d() { return Observable.of('d'); }
+    }
+
+    const mock = new Fixture();
+    const expected = ['a', 'b', 'd'];
+
+    mergeEffects(mock).toArray().subscribe({
+      next(actual) {
+        expect(actual).toEqual(expected);
+      },
+      error: done,
+      complete: done
+    });
+  });
+
+  it('should merge all observable sources prefixed with `effect`', function(done) {
+    class Fixture {
+      effectA = Observable.of('a');
+      effectB = Observable.of('b');
+    }
+
+    const mock = new Fixture();
+    const expected = ['a', 'b'];
+
+    mergeEffects(mock, 'effect').toArray().subscribe({
+      next(actual) {
+        expect(actual).toEqual(expected);
+      },
+      error: done,
+      complete: done
+    });
+  });
 });

--- a/src/effects-subscription.ts
+++ b/src/effects-subscription.ts
@@ -6,6 +6,7 @@ import { merge } from 'rxjs/observable/merge';
 import { mergeEffects } from './effects';
 import { Actions } from './actions';
 
+import { effectsConfig, EffectsConfiguration } from './effects.config';
 
 export const effects = new OpaqueToken('ngrx/effects: Effects');
 
@@ -14,7 +15,8 @@ export class EffectsSubscription extends Subscription implements OnDestroy {
   constructor(
     @Inject(Store) private store: Observer<Actions>,
     @Optional() @SkipSelf() public parent: EffectsSubscription,
-    @Optional() @Inject(effects) effectInstances?: any[]
+    @Optional() @Inject(effects) effectInstances?: any[],
+    @Optional() @Inject(effectsConfig) private effectsConfig?: EffectsConfiguration,
   ) {
     super();
 
@@ -28,7 +30,8 @@ export class EffectsSubscription extends Subscription implements OnDestroy {
   }
 
   addEffects(effectInstances: any[]) {
-    const sources = effectInstances.map(mergeEffects);
+    const registerEffectWithPrefix = this.effectsConfig && this.effectsConfig.registerEffectWithPrefix;
+    const sources = effectInstances.map(instance => mergeEffects(instance, registerEffectWithPrefix));
     const merged = merge(...sources);
 
     this.add(merged.subscribe(this.store));

--- a/src/effects.config.ts
+++ b/src/effects.config.ts
@@ -1,0 +1,7 @@
+import { Injectable, OpaqueToken } from '@angular/core';
+
+export const effectsConfig = new OpaqueToken('ngrx/effects: EffectsConfiguration');
+
+export interface EffectsConfiguration {
+    registerEffectWithPrefix?: string;
+}


### PR DESCRIPTION
Now you can choose between `@Effect()` decorator and custom effect prefix in order to register your effects class. This also helps solve issue #71.

Your root Module declaration:
```ts
import { effectsConfig, EffectsConfiguration } from '@ngrx/effects';

@NgModule({
	providers: [
		{ provide: effectsConfig, useValue: <EffectsConfiguration>{ getEffectsByPrefix: 'effect'}}
	]
})
```

Your effects class:

insted of
```ts
@Injectable()
export class MyEffects {
	@Effect() login() {
	    return this.updates$.whenAction(...).mergeMap(...);
	}
}
```

you could use
```ts
@Injectable()
export class MyEffects {
	effectLogin() {
	    return this.updates$.whenAction(...).mergeMap(...);
	}
}
```