### PR TITLE
Store will only subscribe to observables returning actions

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "url": "https://github.com/ngrx/effects.git"
   },
   "scripts": {
+    "lint": "tslint -c tslint.json 'src/**/*.ts'",
     "karma": "karma start --single-run",
     "test": "nyc node tests.js",
     "test:raw": "node tests.js",
@@ -65,7 +66,7 @@
     "rxjs": "^5.0.0-beta.12",
     "source-map-loader": "^0.1.5",
     "ts-loader": "^0.8.2",
-    "ts-node": "^1.6.0",
+    "ts-node": "^3.0.2",
     "tslint": "^3.15.1",
     "tslint-loader": "^2.1.5",
     "typescript": "^2.0.2",

--- a/spec/actions.spec.ts
+++ b/spec/actions.spec.ts
@@ -14,6 +14,7 @@ describe('Actions', function() {
 
   const ADD = 'ADD';
   const SUBTRACT = 'SUBTRACT';
+  const MULTIPLY = 'MULTIPLY';
 
   function reducer(state: number = 0, action: Action) {
     switch (action.type) {
@@ -65,6 +66,24 @@ describe('Actions', function() {
 
     actions$
       .ofType(ADD)
+      .map(update => update.type)
+      .toArray()
+      .subscribe({
+        next(actual) {
+          expect(actual).toEqual(expected);
+        }
+      });
+
+    actions.forEach(action => dispatcher.dispatch({ type: action }));
+    dispatcher.complete();
+  });
+
+  it('should let you filter out several actions', function() {
+    const actions = [ ADD, ADD, SUBTRACT, ADD, SUBTRACT, MULTIPLY ];
+    const expected = actions.filter(type => type === ADD || type === MULTIPLY);
+
+    actions$
+      .ofType(ADD, MULTIPLY)
       .map(update => update.type)
       .toArray()
       .subscribe({

--- a/src/effects-subscription.ts
+++ b/src/effects-subscription.ts
@@ -4,7 +4,7 @@ import { Observer } from 'rxjs/Observer';
 import { Subscription } from 'rxjs/Subscription';
 import { merge } from 'rxjs/observable/merge';
 import { mergeEffects } from './effects';
-
+import 'rxjs/add/operator/filter';
 
 export const effects = new OpaqueToken('ngrx/effects: Effects');
 
@@ -29,8 +29,7 @@ export class EffectsSubscription extends Subscription implements OnDestroy {
   addEffects(effectInstances: any[]) {
     const sources = effectInstances.map(mergeEffects);
     const merged = merge(...sources);
-
-    this.add(merged.subscribe(this.store));
+    this.add(merged.filter(x => x).subscribe(this.store));
   }
 
   ngOnDestroy() {

--- a/src/effects-subscription.ts
+++ b/src/effects-subscription.ts
@@ -29,7 +29,7 @@ export class EffectsSubscription extends Subscription implements OnDestroy {
   addEffects(effectInstances: any[]) {
     const sources = effectInstances.map(mergeEffects);
     const merged = merge(...sources);
-    this.add(merged.filter(x => x).subscribe(this.store));
+    this.add(merged.filter((x: Action) => !!x && x.type != null).subscribe(this.store));
   }
 
   ngOnDestroy() {

--- a/tslint.json
+++ b/tslint.json
@@ -23,7 +23,9 @@
       true,
       "single"
     ],
-    "semicolon": true,
+    "semicolon":[
+      "always"
+    ],
     "triple-equals": [
       true,
       "allow-null-check"


### PR DESCRIPTION
Fixes #124.

Basically, it only subscribes to the store the observables returning an `Action`, thus avoiding the need of using `dispatch: true | false`. 

I've also updated `ts-node` so that testings can run in `Windows`, upgraded the `code coverage` to 100%, fixed a small issue with `tslint` and added a new `lint` npm script.