### PR TITLE
Add effectsAsSingletons config option

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -6,6 +6,25 @@
 
 Feature module for @ngrx/effects.
 
+### forRoot
+Used to provide optional config for Effects.
+
+Usage:
+```ts
+@NgModule({
+  imports: [
+    EffectsModule.forRoot({ effectsAsSingletons: true })
+  ]
+})
+export class AppModule { }
+```
+
+Using `effectsAsSingletons: true` will cause effects that are passed to
+`EffectModule.run` multiple times (for example in lazy loaded modules) to only
+subscribe once. This is useful if you have effects which are shared amongst
+several lazy loaded features in your application and do not want effects to run
+more than one - e.g. to prevent duplicate http requests being made.
+
 ### run
 
 Registers an effects class to be run immediately when the target module is

--- a/index.ts
+++ b/index.ts
@@ -1,6 +1,6 @@
 export { Effect, mergeEffects } from './src/effects';
 export { Actions } from './src/actions';
-export { EffectsModule } from './src/effects.module';
+export { EffectsModule, EffectsConfig } from './src/effects.module';
 export { EffectsSubscription } from './src/effects-subscription';
 export { toPayload } from './src/util';
 export { runAfterBootstrapEffects } from './src/bootstrap-listener';

--- a/spec/effects-subscription.spec.ts
+++ b/spec/effects-subscription.spec.ts
@@ -2,6 +2,7 @@ import { ReflectiveInjector } from '@angular/core';
 import { of } from 'rxjs/observable/of';
 import { Effect } from '../src/effects';
 import { EffectsSubscription } from '../src/effects-subscription';
+import { SingletonEffectsService } from '../src/singleton-effects.service';
 
 
 describe('Effects Subscription', () => {
@@ -40,5 +41,24 @@ describe('Effects Subscription', () => {
     expect(observer.next).toHaveBeenCalledWith('a');
     expect(observer.next).toHaveBeenCalledWith('b');
     expect(observer.next).toHaveBeenCalledWith('c');
+  });
+
+  it('should not merge duplicate effects instances when a SingletonEffectsService is provided', () => {
+    class Source {
+      @Effect() a$ = of('a');
+      @Effect() b$ = of('b');
+      @Effect() c$ = of('c');
+    }
+    const instance = new Source();
+    const observer: any = { next: jasmine.createSpy('next') };
+    let singletonEffectsService = new SingletonEffectsService();
+    singletonEffectsService.removeExistingAndRegisterNew([ instance ]);
+
+    const subscription = new EffectsSubscription(observer, null, [ instance ], singletonEffectsService);
+
+    expect(observer.next).not.toHaveBeenCalled();
+    expect(observer.next).not.toHaveBeenCalledWith('a');
+    expect(observer.next).not.toHaveBeenCalledWith('b');
+    expect(observer.next).not.toHaveBeenCalledWith('c');
   });
 });

--- a/spec/effects.module.spec.ts
+++ b/spec/effects.module.spec.ts
@@ -1,0 +1,18 @@
+import { EffectsModule } from '../src/effects.module';
+import { SingletonEffectsService } from '../src/singleton-effects.service';
+
+describe('EffectsModule', () => {
+  describe('forRoot', () => {
+    it('should provide the SingletonEffectsService when the userConfig has the effectsAsSingletons flag set', () => {
+      let result = EffectsModule.forRoot({ effectsAsSingletons: true });
+
+      expect(result.providers).toContain(SingletonEffectsService);
+    });
+
+    it('should not provide the SingletonEffectsService when the userConfig does not have the effectsAsSingletons flag', () => {
+      let result = EffectsModule.forRoot();
+
+      expect(result.providers).not.toContain(SingletonEffectsService);
+    });
+  });
+});

--- a/spec/singleton-effects.service.ts
+++ b/spec/singleton-effects.service.ts
@@ -1,0 +1,32 @@
+import { of } from 'rxjs/observable/of';
+import { Effect } from '../src/effects';
+import { SingletonEffectsService } from '../src/singleton-effects.service';
+
+describe('SingletonEffectsService', () => {
+  it('should filter out duplicate effect instances and register new ones', () => {
+    class Source1 {
+      @Effect() a$ = of('a');
+      @Effect() b$ = of('b');
+      @Effect() c$ = of('c');
+    }
+    class Source2 {
+      @Effect() d$ = of('d');
+      @Effect() e$ = of('e');
+      @Effect() f$ = of('f');
+    }
+    const instance1 = new Source1();
+    const instance2 = new Source2();
+    let singletonEffectsService = new SingletonEffectsService();
+
+    let result = singletonEffectsService.removeExistingAndRegisterNew([ instance1 ]);
+    expect(result).toContain(instance1);
+
+    result = singletonEffectsService.removeExistingAndRegisterNew([ instance1, instance2 ]);
+    expect(result).not.toContain(instance1);
+    expect(result).toContain(instance2);
+
+    result = singletonEffectsService.removeExistingAndRegisterNew([ instance1, instance2 ]);
+    expect(result).not.toContain(instance1);
+    expect(result).not.toContain(instance2);
+  });
+});

--- a/src/effects.module.ts
+++ b/src/effects.module.ts
@@ -2,7 +2,11 @@ import { NgModule, Injector, Type, APP_BOOTSTRAP_LISTENER, OpaqueToken } from '@
 import { Actions } from './actions';
 import { EffectsSubscription, effects } from './effects-subscription';
 import { runAfterBootstrapEffects, afterBootstrapEffects } from './bootstrap-listener';
+import { SingletonEffectsService } from './singleton-effects.service';
 
+export interface EffectsConfig {
+  effectsAsSingletons?: boolean;
+}
 
 @NgModule({
   providers: [
@@ -17,6 +21,17 @@ import { runAfterBootstrapEffects, afterBootstrapEffects } from './bootstrap-lis
   ]
 })
 export class EffectsModule {
+  static forRoot(userConfig: EffectsConfig = {}) {
+    let providers = [];
+    if (userConfig.effectsAsSingletons) {
+      providers.push(SingletonEffectsService);
+    }
+    return {
+      ngModule: EffectsModule,
+      providers
+    };
+  }
+
   static run(type: Type<any>) {
     return {
       ngModule: EffectsModule,

--- a/src/singleton-effects.service.ts
+++ b/src/singleton-effects.service.ts
@@ -1,0 +1,17 @@
+import { Injectable } from '@angular/core';
+
+@Injectable()
+export class SingletonEffectsService {
+  private registeredEffects: string[] = [];
+
+  removeExistingAndRegisterNew (effectInstances: any[]): any[] {
+    return effectInstances.filter(instance => {
+      const instanceAsString = instance.constructor.toString();
+      if (this.registeredEffects.indexOf(instanceAsString) === -1) {
+        this.registeredEffects.push(instanceAsString);
+        return true;
+      }
+      return false;
+    });
+  }
+}


### PR DESCRIPTION
As discussed in #123, using `@ngrx/effects` in a larger application which utilises lazy-loaded modules a lot has issues with effects being registered multiple times by features, causing them to run more than once. This is often undesirable, for example if effects are making ajax calls.
Always registering effects in the root module is a workaround, but not a valid solution as this causes the entry bundle to become pretty big.
Knowing which features use which effects and setting up a shared parent module for them does not scale, and requires too much inner knowledge between potentially disparate features.

This PR is one solution for the problem, and builds on the idea from [this repo](https://github.com/FabienDehopre/ngrx-lazy-load/tree/master/src/app/hacked-effects)

I've added a `forRoot` function on EffectsModule which can optionally be called in your application root to provide additional config to EffectsModule. Currently this config is a single flag:
```ts
EffectsModule.forRoot({ effectsAsSingletons: true })
```

Once this flag is set, each time you call `EffectsModule.run` with an effect, the effect will be added to a list of currently registered effects. The next time `.run` is called with that effect, it will be skipped.