### PR TITLE
Fix error with lift method

### DIFF
--- a/src/actions.ts
+++ b/src/actions.ts
@@ -14,7 +14,7 @@ export class Actions extends Observable<Action> {
     this.source = actionsSubject;
   }
 
-  lift(operator: Operator<any, Action>): Observable<Action> {
+  lift<Action>(operator: Operator<any, Action>): Observable<Action> {
     const observable = new Actions(this);
     observable.operator = operator;
     return observable;


### PR DESCRIPTION
fixes #161

The error was:
```log
Class 'Actions' incorrectly extends base class 'Observable<Action>'.
  Types of property 'lift' are incompatible.
    Type '(operator: Operator<any, Action>) => Observable<Action>' is not assignable to type '<R>(operator: Operator<Action, R>) => Observable<R>'.
      Types of parameters 'operator' and 'operator' are incompatible.
        Type 'Operator<Action, R>' is not assignable to type 'Operator<any, Action>'.
          Type 'R' is not assignable to type 'Action'.
```